### PR TITLE
added word-count api

### DIFF
--- a/wordplay/serializers.py
+++ b/wordplay/serializers.py
@@ -13,3 +13,10 @@ class ResponseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Response
         fields = ('word', 'responder', 'responded_at', 'collector')
+
+class WordCountSerializer(serializers.BaseSerializer):
+    def to_representation(self, obj):
+        print "hello %s" % obj
+        return {
+            'count': obj,
+        }

--- a/wordplay/tests/views/test_collector_api_views.py
+++ b/wordplay/tests/views/test_collector_api_views.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+from wordplay import responses, utils
+from wordplay.tests.factories import UserFactory, SurveyFactory, ResponseFactory
+
+
+class WordCountViewTestCases(TestCase):
+    def test_get_count_view(self):
+        team_temp = SurveyFactory()
+        existing_response1 = ResponseFactory(collector=team_temp.current())
+        existing_response2 = ResponseFactory(collector=team_temp.current())
+
+        response = self.client.get(reverse('word_count', args=[str(team_temp.id)]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'word')
+        self.assertContains(response, '2')

--- a/wordplay/urls.py
+++ b/wordplay/urls.py
@@ -25,7 +25,8 @@ urlpatterns = patterns(
     url(r'^(?P<pk>[0-9a-zA-Z]{8})/cloud/$', CloudView.as_view(), name='cloud'),
     url(r'^([0-9a-zA-Z]{8})$', submit, name='temp'),
     url(r'^static/(.*)$', 'django.views.static.serve', {'document_root': settings.STATIC_ROOT}),
-    url(r'^api/response/$', views.WordListView.as_view(), name='response'),
+    url(r'^api/responses/(?P<pk>[0-9a-zA-Z]{8})/$', views.WordListView.as_view(), name='response'),
+    url(r'^api/wordcount/(?P<pk>[0-9a-zA-Z]{8})/$', views.word_count, name='word_count'),
     url(r'^api/', include(router.urls)),
     url(r'^api/api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 )


### PR DESCRIPTION
added an api to count the words for the current collector for a given survey. See the example below.

```
GET /api/wordcount/wQKrAOP4/
HTTP 200 OK
Content-Type: application/json
Vary: Accept
Allow: OPTIONS, GET

{
    "count": {
        "hippo": 1,
        "donkey": 1,
        "new": 2
    }
}
```

Also refactored the WordListView to use the .current operator of the Survey model to determine the current collector.
